### PR TITLE
Split retrieving users by email/user_id from retrieving them by id

### DIFF
--- a/lib/Intercom/Client.pm
+++ b/lib/Intercom/Client.pm
@@ -23,7 +23,7 @@ Intercom::Client - Perl SDK for the Intercom REST API
 
     my $client = Intercom::Client->new({token => $access_token});
 
-    my $user = $client->users->get({email => $email});
+    my $user = $client->users->search({email => $email});
 
 =head1 DESCRIPTION
 

--- a/lib/Intercom/Client/RequestHandler.pm
+++ b/lib/Intercom/Client/RequestHandler.pm
@@ -393,7 +393,8 @@ sub _construct_scrollable_paginator {
         my ($self, $type) = @_;
 
         return try {
-            return use_module('Intercom::Resource::'.$type_map->{$type});
+            my $mapped_type = $type_map->{$type} || die 'No Type class for $type';
+            return use_module('Intercom::Resource::'.$mapped_type);
         } catch {
             confess "Unable to find resource for [$type]"
         };

--- a/lib/Intercom/Client/User.pm
+++ b/lib/Intercom/Client/User.pm
@@ -15,7 +15,13 @@ Intercom::Client::User - User Resource class
 
 =head1 SYNOPSIS
 
-    my $user = $client->users->get({id => 1});
+    my $users = $client->users->search({email => 'test1@test.com});
+    my $user = $users->users->[0];
+
+    $user = $client->users->update({
+        id    => $user->id,
+        email => 'test2@test.com'
+    });
 
 =head1 DESCRIPTION
 
@@ -139,16 +145,11 @@ sub list {
     return $self->request_handler->get($uri);
 }
 
-=head3 get (HashRef $params) -> Intercom::Resource::User|Intercom::Resource::ErrorList
+=head3 get (Str $id) -> Intercom::Resource::User|Intercom::Resource::ErrorList
 
-    my $user = $client->users->get({id => 1});
-    my $user2 = $client->users->get({email => 'test@test.com'});
-    my $user3 = $client->users->get({user_id => '12333'});
+    my $user = $client->users->get(1);
 
-Retrieve a user based on their primary intercom ID ($params->{id})
-
-alternatively retrieve a user as identified by their email ($params->{email})
-or custom user_id ($params->{user_id})
+Retrieve a user based on their primary intercom ID ($id)
 
 Returns either an instance of an Intercom::Resource::User or an instance of an Intercom::Resource::ErrorList
 
@@ -157,8 +158,41 @@ SEE ALSO: L<View a User|https://developers.intercom.com/intercom-api-reference/v
 =cut
 
 sub get {
+    my ($self, $id) = @_;
+
+    unless ($id) {
+        return Intercom::Resource::ErrorList->new(errors => [{
+            code => 'parameter_not_found',
+            message => 'Get requires an `id` parameter'
+        }]);
+    }
+
+    return $self->request_handler->get($self->_user_path({id => $id}));
+}
+
+=head3 search (HashRef $params) -> Intercom::Resource::UserList|Intercom::Resource::ErrorList
+
+    my $user2 = $client->users->search({email => 'test@test.com'});
+    my $user3 = $client->users->search({user_id => '12333'});
+
+Search for users as identified by an email ($params->{email})
+or custom user_id ($params->{user_id})
+
+Returns either an instance of an Intercom::Resource::UserList or an instance of an Intercom::Resource::ErrorList
+
+SEE ALSO: L<Search Users|https://developers.intercom.com/intercom-api-reference/v1.1/reference#view-a-user>
+
+=cut
+
+sub search {
     my ($self, $params) = @_;
 
+    unless ($params->{email} || $params->{user_id}) {
+        return Intercom::Resource::ErrorList->new(errors => [{
+            code => 'parameter_not_found',
+            message => 'Search requires one of `email` or `user_id`'
+        }]);
+    }
     return $self->request_handler->get($self->_user_path($params));
 }
 

--- a/lib/Intercom/Client/User.pm
+++ b/lib/Intercom/Client/User.pm
@@ -245,6 +245,12 @@ SEE ALSO: L<Archive a User|https://developers.intercom.com/intercom-api-referenc
 sub archive {
     my ($self, $params) = @_;
 
+    unless ($params->{id} || $params->{email} || $params->{user_id}) {
+        return Intercom::Resource::ErrorList->new(errors => [{
+            code => 'parameter_not_found',
+            message => 'Search requires one of `email` or `user_id`'
+        }]);
+    }
     return $self->request_handler->delete($self->_user_path($params));
 }
 

--- a/t/intergration/user/archive.t
+++ b/t/intergration/user/archive.t
@@ -1,7 +1,7 @@
 use lib 't/lib';
 
 use JSON;
-use Test::Most tests => 6;
+use Test::Most tests => 5;
 use Test::MockObject;
 use Test::Mock::LWP::Dispatch;
 use SharedTests::Request;
@@ -9,15 +9,7 @@ use SharedTests::User;
 
 use Intercom::Client;
 
-SharedTests::Request::headers(sub {
-    return shift->users->archive({email => 'test@test.com'});
-});
-
-SharedTests::Request::auth_failure(sub {
-    return shift->users->archive({email => 'test@test.com'});
-});
-
-SharedTests::Request::connection_failure(sub {
+SharedTests::Request::all_tests(sub {
     return shift->users->archive({email => 'test@test.com'});
 });
 
@@ -101,6 +93,18 @@ subtest 'via UserID' => sub {
     });
 
     SharedTests::User::test_resource_generation($client->users->archive({user_id => 23134}), $user_data);
+};
+
+subtest 'Missing param' => sub {
+    my $mock_ua = LWP::UserAgent->new();
+    my $client = Intercom::Client->new({
+        access_token => 'test',
+        ua           => $mock_ua
+    });
+
+    my $errors = $client->users->archive();
+
+    is($errors->errors->[0]{code}, 'parameter_not_found', 'Error returned');
 };
 
 sub user_data {

--- a/t/intergration/user/create.t
+++ b/t/intergration/user/create.t
@@ -1,7 +1,7 @@
 use lib 't/lib';
 
 use JSON;
-use Test::Most tests => 4;
+use Test::Most tests => 2;
 use Test::MockObject;
 use Test::Mock::LWP::Dispatch;
 use SharedTests::Request;
@@ -9,15 +9,7 @@ use SharedTests::User;
 
 use Intercom::Client;
 
-SharedTests::Request::headers(sub {
-    return shift->users->create({email => 'test@test.com'});
-});
-
-SharedTests::Request::auth_failure(sub {
-    return shift->users->create({email => 'test@test.com'});
-});
-
-SharedTests::Request::connection_failure(sub {
+SharedTests::Request::all_tests(sub {
     return shift->users->create({email => 'test@test.com'});
 });
 

--- a/t/intergration/user/get.t
+++ b/t/intergration/user/get.t
@@ -1,7 +1,7 @@
 use lib 't/lib';
 
 use JSON;
-use Test::Most tests => 4;
+use Test::Most tests => 3;
 use Test::MockObject;
 use Test::Mock::LWP::Dispatch;
 use SharedTests::Request;
@@ -9,15 +9,7 @@ use SharedTests::User;
 
 use Intercom::Client;
 
-SharedTests::Request::headers(sub {
-    return shift->users->get(1);
-});
-
-SharedTests::Request::auth_failure(sub {
-    return shift->users->get(1);
-});
-
-SharedTests::Request::connection_failure(sub {
+SharedTests::Request::all_tests(sub {
     return shift->users->get(1);
 });
 
@@ -47,6 +39,18 @@ subtest 'via ID' => sub {
 
     my $resource = $client->users->get(1);
     SharedTests::User::test_resource_generation($resource, $user_data);
+};
+
+subtest 'Missing param' => sub {
+    my $mock_ua = LWP::UserAgent->new();
+    my $client = Intercom::Client->new({
+        access_token => 'test',
+        ua           => $mock_ua
+    });
+
+    my $errors = $client->users->get();
+
+    is($errors->errors->[0]{code}, 'parameter_not_found', 'Error returned');
 };
 
 sub user_data {

--- a/t/intergration/user/get.t
+++ b/t/intergration/user/get.t
@@ -1,7 +1,7 @@
 use lib 't/lib';
 
 use JSON;
-use Test::Most tests => 6;
+use Test::Most tests => 4;
 use Test::MockObject;
 use Test::Mock::LWP::Dispatch;
 use SharedTests::Request;
@@ -10,15 +10,15 @@ use SharedTests::User;
 use Intercom::Client;
 
 SharedTests::Request::headers(sub {
-    return shift->users->get({email => 'test@test.com'});
+    return shift->users->get(1);
 });
 
 SharedTests::Request::auth_failure(sub {
-    return shift->users->get({email => 'test@test.com'});
+    return shift->users->get(1);
 });
 
 SharedTests::Request::connection_failure(sub {
-    return shift->users->get({email => 'test@test.com'});
+    return shift->users->get(1);
 });
 
 subtest 'via ID' => sub {
@@ -45,62 +45,8 @@ subtest 'via ID' => sub {
         ua         => $mock_ua
     });
 
-    my $resource = $client->users->get({id => 1});
+    my $resource = $client->users->get(1);
     SharedTests::User::test_resource_generation($resource, $user_data);
-};
-
-subtest 'via Email' => sub {
-    plan tests => 1;
-
-    my $user_data = user_data();
-
-    my $mock_ua = LWP::UserAgent->new();
-    $mock_ua->map(qr#/users\?email=test%40test\.com$# => sub {
-        my ($request) = @_;
-        my $response = HTTP::Response->new(
-            '200',
-            'OK',
-            [ 'Content-Type' => 'application/json' ],
-            JSON::encode_json($user_data)
-        );
-
-        $response->request($request);
-        return $response;
-    });
-
-    my $client = Intercom::Client->new({
-        access_token => 'test',
-        ua         => $mock_ua
-    });
-
-    SharedTests::User::test_resource_generation($client->users->get({email => 'test@test.com'}), $user_data);
-};
-
-subtest 'via UserID' => sub {
-    plan tests => 1;
-
-    my $user_data = user_data();
-
-    my $mock_ua = LWP::UserAgent->new();
-    $mock_ua->map(qr#/users\?user_id=23134# => sub {
-        my ($request) = @_;
-        my $response = HTTP::Response->new(
-            '200',
-            'OK',
-            [ 'Content-Type' => 'application/json' ],
-            JSON::encode_json($user_data)
-        );
-
-        $response->request($request);
-        return $response;
-    });
-
-    my $client = Intercom::Client->new({
-        access_token => 'test',
-        ua           => $mock_ua
-    });
-
-    SharedTests::User::test_resource_generation($client->users->get({user_id => 23134}), $user_data);
 };
 
 sub user_data {

--- a/t/intergration/user/permanently_delete.t
+++ b/t/intergration/user/permanently_delete.t
@@ -1,22 +1,14 @@
 use lib 't/lib';
 
 use JSON;
-use Test::Most tests => 4;
+use Test::Most tests => 2;
 use Test::MockObject;
 use Test::Mock::LWP::Dispatch;
 use SharedTests::Request;
 
 use Intercom::Client;
 
-SharedTests::Request::headers(sub {
-    return shift->users->permanently_delete({email => 'test@test.com'});
-});
-
-SharedTests::Request::auth_failure(sub {
-    return shift->users->permanently_delete({email => 'test@test.com'});
-});
-
-SharedTests::Request::connection_failure(sub {
+SharedTests::Request::all_tests(sub {
     return shift->users->permanently_delete({email => 'test@test.com'});
 });
 

--- a/t/intergration/user/scroll.t
+++ b/t/intergration/user/scroll.t
@@ -1,7 +1,7 @@
 use lib 't/lib';
 
 use JSON;
-use Test::Most tests => 5;
+use Test::Most tests => 3;
 use Test::MockObject;
 use Test::Mock::LWP::Dispatch;
 use SharedTests::Request;
@@ -9,15 +9,7 @@ use SharedTests::User;
 
 use Intercom::Client;
 
-SharedTests::Request::headers(sub {
-    return shift->users->scroll({email => 'test@test.com'});
-});
-
-SharedTests::Request::auth_failure(sub {
-    return shift->users->scroll({email => 'test@test.com'});
-});
-
-SharedTests::Request::connection_failure(sub {
+SharedTests::Request::all_tests(sub {
     return shift->users->scroll({email => 'test@test.com'});
 });
 

--- a/t/intergration/user/update.t
+++ b/t/intergration/user/update.t
@@ -1,7 +1,7 @@
 use lib 't/lib';
 
 use JSON;
-use Test::Most tests => 5;
+use Test::Most tests => 3;
 use Test::MockObject;
 use Test::Mock::LWP::Dispatch;
 use SharedTests::Request;
@@ -9,15 +9,7 @@ use SharedTests::User;
 
 use Intercom::Client;
 
-SharedTests::Request::headers(sub {
-    return shift->users->update({email => 'test@test.com'});
-});
-
-SharedTests::Request::auth_failure(sub {
-    return shift->users->update({email => 'test@test.com'});
-});
-
-SharedTests::Request::connection_failure(sub {
+SharedTests::Request::all_tests(sub {
     return shift->users->update({email => 'test@test.com'});
 });
 

--- a/t/lib/SharedTests/Request.pm
+++ b/t/lib/SharedTests/Request.pm
@@ -46,6 +46,7 @@ sub all_tests {
         auth_failure($call);
         headers($call);
         connection_failure($call);
+        unrecognised_type($call);
     };
 }
 
@@ -231,7 +232,7 @@ sub unrecognised_type {
                 200,
                 'OK',
                 [ 'Content-type' => 'application/json' ],
-                '{"type": "unkown_type", "data": "random_data"}'
+                '{"type": "unknown_type", "data": "random_data"}'
             );
 
             $response->request($request);
@@ -246,7 +247,7 @@ sub unrecognised_type {
 
         throws_ok(
             sub { $call->($client); },
-            qr/Unable to find resource for \[unknown_type\]/,
+            qr/^Unable to find resource for \[unknown_type\]/,
             'Threw error for unknown type'
         );
     };

--- a/t/unit/intercom/client/user/archive.t
+++ b/t/unit/intercom/client/user/archive.t
@@ -1,4 +1,4 @@
-use Test::Most tests => 3;
+use Test::Most tests => 4;
 use Test::MockObject;
 use Test::MockObject::Extends;
 
@@ -77,4 +77,23 @@ subtest 'By user_id' => sub {
     });
 
     is($user->archive({user_id => 2}), 'test', 'Correct response returned');
+};
+
+subtest 'Missing params' => sub {
+    plan tests => 1;
+
+    my $request_handler = Test::MockObject->new();
+    $request_handler->mock('delete', sub {
+        fail('Called RH->get');
+    });
+
+    my $user = Test::MockObject::Extends->new(
+        Intercom::Client::User->new(request_handler => $request_handler)
+    );
+
+    is(
+        $user->archive()->errors->[0]{code},
+        'parameter_not_found',
+        'Correct response returned'
+    );
 };

--- a/t/unit/intercom/client/user/get.t
+++ b/t/unit/intercom/client/user/get.t
@@ -1,4 +1,4 @@
-use Test::Most tests => 3;
+use Test::Most tests => 2;
 use Test::MockObject;
 use Test::MockObject::Extends;
 
@@ -18,63 +18,33 @@ subtest 'By ID' => sub {
     my $user = Test::MockObject::Extends->new(
         Intercom::Client::User->new(request_handler => $request_handler)
     );
+
     $user->mock(_user_path => sub {
         my ($self, $params) = @_;
 
-        cmp_deeply($params, {id => 1}, 'Passed ID through to _user_path');
+        cmp_deeply($params, {id => 1}, 'Passed id through to _user_path');
 
         return '/users/1';
     });
-
-    is($user->get({id => 1}), 'test', 'Correct response returned');
+    is($user->get(1), 'test', 'Correct response returned');
 };
 
-subtest 'By email' => sub {
-    plan tests => 3;
+subtest 'missing id' => sub {
+    plan tests => 1;
 
     my $request_handler = Test::MockObject->new();
     $request_handler->mock('get', sub {
-        my ($self, $uri) = @_;
-
-        is($uri, '/users?email=test%40test.com', 'value of _user_path correctly passed to RH->get()');
-        return 'test';
+        fail('Called RH->get');
     });
 
-    my $user = Test::MockObject::Extends->new(
-        Intercom::Client::User->new(request_handler => $request_handler)
+    my $user = Intercom::Client::User->new(
+        request_handler => $request_handler
     );
-    $user->mock(_user_path => sub {
-        my ($self, $params) = @_;
 
-        cmp_deeply($params, {email => 'test@test.com'}, 'Passed email through to _user_path');
-
-        return '/users?email=test%40test.com';
-    });
-
-    is($user->get({email => 'test@test.com'}), 'test', 'Correct response returned');
+    is(
+        $user->get()->errors->[0]->{code},
+        'parameter_not_found',
+        'Correct response returned'
+    );
 };
 
-subtest 'By user_id' => sub {
-    plan tests => 3;
-
-    my $request_handler = Test::MockObject->new();
-    $request_handler->mock('get', sub {
-        my ($self, $uri) = @_;
-
-        is($uri, '/users?user_id=2', 'value of _user_path correctly passed to RH->get()');
-        return 'test';
-    });
-
-    my $user = Test::MockObject::Extends->new(
-        Intercom::Client::User->new(request_handler => $request_handler)
-    );
-    $user->mock(_user_path => sub {
-        my ($self, $params) = @_;
-
-        cmp_deeply($params, {user_id => '2'}, 'Passed email through to _user_path');
-
-        return '/users?user_id=2';
-    });
-
-    is($user->get({user_id => 2}), 'test', 'Correct response returned');
-};

--- a/t/unit/intercom/client/user/search.t
+++ b/t/unit/intercom/client/user/search.t
@@ -1,4 +1,4 @@
-use Test::Most tests => 2;
+use Test::Most tests => 3;
 use Test::MockObject;
 use Test::MockObject::Extends;
 
@@ -52,4 +52,23 @@ subtest 'By user_id' => sub {
     });
 
     is($user->search({user_id => 2}), 'test', 'Correct response returned');
+};
+
+subtest 'Missing params' => sub {
+    plan tests => 1;
+
+    my $request_handler = Test::MockObject->new();
+    $request_handler->mock('get', sub {
+        fail('Called RH->get');
+    });
+
+    my $user = Test::MockObject::Extends->new(
+        Intercom::Client::User->new(request_handler => $request_handler)
+    );
+
+    is(
+        $user->search()->errors->[0]{code},
+        'parameter_not_found',
+        'Correct response returned'
+    );
 };

--- a/t/unit/intercom/client/user/search.t
+++ b/t/unit/intercom/client/user/search.t
@@ -1,0 +1,55 @@
+use Test::Most tests => 2;
+use Test::MockObject;
+use Test::MockObject::Extends;
+
+use Intercom::Client::User;
+
+subtest 'By email' => sub {
+    plan tests => 3;
+
+    my $request_handler = Test::MockObject->new();
+    $request_handler->mock('get', sub {
+        my ($self, $uri) = @_;
+
+        is($uri, '/users?email=test%40test.com', 'value of _user_path correctly passed to RH->search()');
+        return 'test';
+    });
+
+    my $user = Test::MockObject::Extends->new(
+        Intercom::Client::User->new(request_handler => $request_handler)
+    );
+    $user->mock(_user_path => sub {
+        my ($self, $params) = @_;
+
+        cmp_deeply($params, {email => 'test@test.com'}, 'Passed email through to _user_path');
+
+        return '/users?email=test%40test.com';
+    });
+
+    is($user->search({email => 'test@test.com'}), 'test', 'Correct response returned');
+};
+
+subtest 'By user_id' => sub {
+    plan tests => 3;
+
+    my $request_handler = Test::MockObject->new();
+    $request_handler->mock('get', sub {
+        my ($self, $uri) = @_;
+
+        is($uri, '/users?user_id=2', 'value of _user_path correctly passed to RH->search()');
+        return 'test';
+    });
+
+    my $user = Test::MockObject::Extends->new(
+        Intercom::Client::User->new(request_handler => $request_handler)
+    );
+    $user->mock(_user_path => sub {
+        my ($self, $params) = @_;
+
+        cmp_deeply($params, {user_id => '2'}, 'Passed email through to _user_path');
+
+        return '/users?user_id=2';
+    });
+
+    is($user->search({user_id => 2}), 'test', 'Correct response returned');
+};


### PR DESCRIPTION
#### Why?
User->get previously returned either a single User or a UserList. This provided an interface that was not as easy to use as it could be

#### How?
Separate the retrieval by ID from the retrieval of users by email/user_id. 

